### PR TITLE
Introduce lazy exports in package init and add governance download strategy with tests

### DIFF
--- a/rafaelia/__init__.py
+++ b/rafaelia/__init__.py
@@ -37,6 +37,12 @@ Philosophy: VAZIO → VERBO → CHEIO → RETRO
 Motto: Haja Lux, Haja Etica
 """
 
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from typing import Dict, Tuple
+
 __version__ = "1.0.0"
 __author__ = "Rafael Melo Reis (rafaelmeloreisnovo)"
 __copyright__ = "Copyright (C) 2025 Rafael Melo Reis"
@@ -45,49 +51,68 @@ __institution__ = "Instituto Rafael"
 __framework__ = "ESTADO FRACTAL HAJA & ZIPRAF_OMEGA v999"
 __philosophy__ = "CientiEspiritual"
 
-# Core TT algorithms
-from rafaelia.core.tt_cross import TTCrossApproximation
-from rafaelia.core.tt_update import TTLocalUpdate
+_LAZY_EXPORTS: Dict[str, Tuple[str, str]] = {
+    # Core algorithms
+    "TTCrossApproximation": ("rafaelia.core.tt_cross", "TTCrossApproximation"),
+    "TTLocalUpdate": ("rafaelia.core.tt_update", "TTLocalUpdate"),
+    # Utilities
+    "FibonacciSpiral": ("rafaelia.utils.spiral", "FibonacciSpiral"),
+    "GoldenRatioSampler": ("rafaelia.utils.spiral", "GoldenRatioSampler"),
+    "TTAccelerator": ("rafaelia.utils.acceleration", "TTAccelerator"),
+    # Integration
+    "RAFAELIAEngine": ("rafaelia.integration.engine", "RAFAELIAEngine"),
+    # Governance
+    "governance": ("rafaelia.governance", ""),
+}
 
-# Utilities
-from rafaelia.utils.spiral import FibonacciSpiral, GoldenRatioSampler
-from rafaelia.utils.acceleration import TTAccelerator
+_OPTIONAL_IMPORT_HINTS: Dict[str, str] = {
+    "numpy": "Install the RAFAELIA numerical dependencies before using TT algorithms.",
+}
 
-# Integration/Orchestration
-from rafaelia.integration.engine import RAFAELIAEngine
 
-# Governance Framework (ZIPRAF_OMEGA v999)
-# Import governance submodule for comprehensive compliance and ethical framework
-try:
-    from rafaelia import governance
-    __governance_available__ = True
-except ImportError:
-    __governance_available__ = False
+def _missing_optional_dependency(module_name: str) -> str:
+    for dependency, hint in _OPTIONAL_IMPORT_HINTS.items():
+        if importlib.util.find_spec(dependency) is None:
+            return f"Optional dependency '{dependency}' is unavailable. {hint}"
+    return f"Unable to import optional RAFAELIA module '{module_name}'."
+
+
+def __getattr__(name: str):
+    """Lazy-load heavy RAFAELIA exports without breaking lightweight imports."""
+
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module 'rafaelia' has no attribute {name!r}")
+
+    module_name, attribute_name = _LAZY_EXPORTS[name]
+    if importlib.util.find_spec(module_name) is None:
+        raise ImportError(_missing_optional_dependency(module_name))
+    module = importlib.import_module(module_name)
+    value = module if not attribute_name else getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+__governance_available__ = importlib.util.find_spec("rafaelia.governance") is not None
 
 __all__ = [
     # Core algorithms
-    'TTCrossApproximation',
-    'TTLocalUpdate',
-    
+    "TTCrossApproximation",
+    "TTLocalUpdate",
     # Utilities
-    'FibonacciSpiral',
-    'GoldenRatioSampler',
-    'TTAccelerator',
-    
+    "FibonacciSpiral",
+    "GoldenRatioSampler",
+    "TTAccelerator",
     # Integration
-    'RAFAELIAEngine',
-    
+    "RAFAELIAEngine",
     # Governance
-    'governance',
-    
+    "governance",
     # Metadata
-    '__version__',
-    '__author__',
-    '__copyright__',
-    '__license__',
-    '__institution__',
-    '__framework__',
-    '__philosophy__',
-    '__governance_available__',
+    "__version__",
+    "__author__",
+    "__copyright__",
+    "__license__",
+    "__institution__",
+    "__framework__",
+    "__philosophy__",
+    "__governance_available__",
 ]
-

--- a/rafaelia/governance/download_strategy.py
+++ b/rafaelia/governance/download_strategy.py
@@ -1,0 +1,299 @@
+"""Enterprise-safe download strategy primitives for RAFAELIA governance.
+
+This module is a decision layer, not a downloader.  It performs no network I/O,
+creates no subprocesses, and mutates no system state.  Callers provide artifact
+metadata plus a bounded content stream; the module classifies the artifact,
+validates compatibility/security constraints, chooses a deterministic primary
+mirror, exposes bounded failover mirrors, and returns a rollback-ready audit
+manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
+
+
+class DownloadState(str, Enum):
+    """Operational state produced by the download strategy."""
+
+    READY = "READY"
+    FAILOVER = "FAILOVER"
+    ROLLBACK = "ROLLBACK"
+    REJECTED = "REJECTED"
+
+
+class ContentKind(str, Enum):
+    """Recognized artifact families allowed by the secure download pipeline."""
+
+    APK = "apk"
+    ZIP = "zip"
+    JSON = "json"
+    TEXT = "text"
+    BINARY = "binary"
+    UNKNOWN = "unknown"
+
+
+class SafetyFlag(str, Enum):
+    """Reason flags kept stable for automation, dashboards, and rollback gates."""
+
+    CONTENT_BLOCKED = "CONTENT_BLOCKED"
+    DIGEST_MISMATCH = "DIGEST_MISMATCH"
+    HASH_FORMAT_INVALID = "HASH_FORMAT_INVALID"
+    NO_CANDIDATES = "NO_CANDIDATES"
+    SIZE_LIMIT = "SIZE_LIMIT"
+    URL_SCHEME_BLOCKED = "URL_SCHEME_BLOCKED"
+    WATCHDOG_TIMEOUT = "WATCHDOG_TIMEOUT"
+    MIN_MIRRORS_UNMET = "MIN_MIRRORS_UNMET"
+    POLICY_INVALID = "POLICY_INVALID"
+
+
+_MAGIC_TABLE: Tuple[Tuple[bytes, ContentKind], ...] = (
+    (b"PK\x03\x04", ContentKind.ZIP),
+    (b"{", ContentKind.JSON),
+    (b"[", ContentKind.JSON),
+)
+
+_EXTENSION_TABLE: Mapping[str, ContentKind] = {
+    ".apk": ContentKind.APK,
+    ".zip": ContentKind.ZIP,
+    ".json": ContentKind.JSON,
+    ".txt": ContentKind.TEXT,
+    ".md": ContentKind.TEXT,
+}
+
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+@dataclass(frozen=True)
+class DownloadCandidate:
+    """Single immutable download source description."""
+
+    url: str
+    expected_sha256: str
+    size_bytes: int
+    priority: int = 100
+    compatibility: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class WatchdogPolicy:
+    """Bounded operational guardrails for a download transaction."""
+
+    timeout_seconds: float = 30.0
+    max_retries: int = 2
+    max_size_bytes: int = 512 * 1024 * 1024
+    min_viable_mirrors: int = 1
+    required_compatibility: Tuple[str, ...] = ()
+    allowed_schemes: Tuple[str, ...] = ("https", "file")
+    allowed_kinds: Tuple[ContentKind, ...] = (
+        ContentKind.APK,
+        ContentKind.ZIP,
+        ContentKind.JSON,
+        ContentKind.TEXT,
+    )
+
+
+@dataclass(frozen=True)
+class RollbackPlan:
+    """Explicit rollback data for the caller's deployment layer."""
+
+    snapshot_path: str
+    restore_path: str
+    reason: str
+    required: bool
+
+
+@dataclass(frozen=True)
+class StrategyDecision:
+    """Result of validating a content sample and its candidate mirrors."""
+
+    state: DownloadState
+    kind: ContentKind
+    selected_url: Optional[str]
+    failover_urls: Tuple[str, ...]
+    digest: str
+    flags: Tuple[SafetyFlag, ...] = field(default_factory=tuple)
+    reasons: Tuple[str, ...] = field(default_factory=tuple)
+    rollback: Optional[RollbackPlan] = None
+
+
+def recognize_content(name: str, prefix: bytes) -> ContentKind:
+    """Recognize a download artifact from extension and a small content prefix."""
+
+    suffix = Path(name).suffix.lower()
+    if suffix == ".apk":
+        return ContentKind.APK
+    if suffix in _EXTENSION_TABLE:
+        return _EXTENSION_TABLE[suffix]
+    trimmed = prefix.lstrip()[:4]
+    for magic, kind in _MAGIC_TABLE:
+        if trimmed.startswith(magic):
+            return kind
+    if prefix and all(byte in b"\t\n\r" or 32 <= byte <= 126 for byte in prefix[:128]):
+        return ContentKind.TEXT
+    return ContentKind.BINARY if prefix else ContentKind.UNKNOWN
+
+
+def sha256_bytes(chunks: Iterable[bytes]) -> str:
+    """Compute SHA-256 incrementally from byte chunks."""
+
+    digest = hashlib.sha256()
+    for chunk in chunks:
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _valid_sha256(value: str) -> bool:
+    return len(value) == 64 and all(character in _HEX_DIGITS for character in value)
+
+
+def _candidate_scheme(candidate: DownloadCandidate) -> str:
+    parsed = urlparse(candidate.url)
+    if parsed.scheme:
+        return parsed.scheme.lower()
+    return "file" if candidate.url.startswith("/") else ""
+
+
+def _is_compatible(candidate: DownloadCandidate, required: Tuple[str, ...]) -> bool:
+    if not required:
+        return True
+    supported = frozenset(candidate.compatibility)
+    return all(flag in supported for flag in required)
+
+
+def _flag(flags: List[SafetyFlag], flag: SafetyFlag) -> None:
+    if flag not in flags:
+        flags.append(flag)
+
+
+def _terminal_state(rollback: Optional[RollbackPlan]) -> DownloadState:
+    return DownloadState.ROLLBACK if rollback and rollback.required else DownloadState.REJECTED
+
+
+def build_download_strategy(
+    name: str,
+    content_prefix: bytes,
+    content_chunks: Iterable[bytes],
+    candidates: Sequence[DownloadCandidate],
+    policy: WatchdogPolicy,
+    rollback: Optional[RollbackPlan] = None,
+    now: Optional[float] = None,
+    started_at: Optional[float] = None,
+) -> StrategyDecision:
+    """Validate artifact metadata and choose a primary source plus failovers.
+
+    The function is deterministic when ``now`` is supplied. ``started_at`` can
+    be supplied by callers to make watchdog elapsed-time checks cover earlier
+    pipeline phases such as DNS, TLS, download, staging, and scan. It returns
+    ``READY`` when all guardrails pass, ``FAILOVER`` when at least one candidate
+    was rejected but a safe route remains, ``ROLLBACK`` when no safe route
+    remains and rollback is mandatory, otherwise ``REJECTED``.
+    """
+
+    clock_value = time.monotonic() if now is None else now
+    watchdog_started_at = clock_value if started_at is None else started_at
+    kind = recognize_content(name, content_prefix)
+    digest = sha256_bytes(content_chunks)
+    ordered = tuple(sorted(candidates, key=lambda item: (item.priority, item.url)))
+    flags: List[SafetyFlag] = []
+    reasons: List[str] = []
+
+    if kind not in policy.allowed_kinds:
+        _flag(flags, SafetyFlag.CONTENT_BLOCKED)
+        reasons.append(f"content kind {kind.value} is not allowed")
+    if not ordered:
+        _flag(flags, SafetyFlag.NO_CANDIDATES)
+        reasons.append("no download candidates supplied")
+    if policy.timeout_seconds < 0 or policy.max_retries < 0 or policy.max_size_bytes < 0:
+        _flag(flags, SafetyFlag.POLICY_INVALID)
+        reasons.append("watchdog policy contains a negative bound")
+    if policy.min_viable_mirrors < 1:
+        _flag(flags, SafetyFlag.POLICY_INVALID)
+        reasons.append("minimum viable mirror count must be at least one")
+
+    elapsed = (time.monotonic() if now is None else clock_value) - watchdog_started_at
+    if elapsed > policy.timeout_seconds:
+        _flag(flags, SafetyFlag.WATCHDOG_TIMEOUT)
+        reasons.append("watchdog timeout before validation completed")
+
+    viable: List[DownloadCandidate] = []
+    for candidate in ordered:
+        if candidate.size_bytes > policy.max_size_bytes:
+            _flag(flags, SafetyFlag.SIZE_LIMIT)
+            reasons.append(f"candidate too large: {candidate.url}")
+            continue
+        if _candidate_scheme(candidate) not in policy.allowed_schemes:
+            _flag(flags, SafetyFlag.URL_SCHEME_BLOCKED)
+            reasons.append(f"candidate URL scheme blocked: {candidate.url}")
+            continue
+        if not _valid_sha256(candidate.expected_sha256):
+            _flag(flags, SafetyFlag.HASH_FORMAT_INVALID)
+            reasons.append(f"sha256 format invalid: {candidate.url}")
+            continue
+        if candidate.expected_sha256.lower() != digest:
+            _flag(flags, SafetyFlag.DIGEST_MISMATCH)
+            reasons.append(f"sha256 mismatch: {candidate.url}")
+            continue
+        if not _is_compatible(candidate, policy.required_compatibility):
+            _flag(flags, SafetyFlag.MIN_MIRRORS_UNMET)
+            reasons.append(f"candidate lacks required compatibility: {candidate.url}")
+            continue
+        viable.append(candidate)
+
+    if len(viable) < policy.min_viable_mirrors:
+        _flag(flags, SafetyFlag.MIN_MIRRORS_UNMET)
+        reasons.append("minimum viable mirror count was not met")
+
+    terminal_flags = (SafetyFlag.WATCHDOG_TIMEOUT, SafetyFlag.POLICY_INVALID)
+    if any(flag in flags for flag in terminal_flags) or not viable or len(viable) < policy.min_viable_mirrors:
+        state = _terminal_state(rollback)
+        return StrategyDecision(
+            state=state,
+            kind=kind,
+            selected_url=None,
+            failover_urls=(),
+            digest=digest,
+            flags=tuple(flags),
+            reasons=tuple(reasons),
+            rollback=rollback if state is DownloadState.ROLLBACK else None,
+        )
+
+    selected = viable[0]
+    failovers = tuple(candidate.url for candidate in viable[1 : policy.max_retries + 1])
+    state = DownloadState.FAILOVER if flags else DownloadState.READY
+    return StrategyDecision(
+        state=state,
+        kind=kind,
+        selected_url=selected.url,
+        failover_urls=failovers,
+        digest=digest,
+        flags=tuple(flags),
+        reasons=tuple(reasons),
+        rollback=None,
+    )
+
+
+def decision_manifest(decision: StrategyDecision) -> Dict[str, object]:
+    """Serialize a strategy decision into an audit-friendly manifest."""
+
+    return {
+        "state": decision.state.value,
+        "kind": decision.kind.value,
+        "selected_url": decision.selected_url,
+        "failover_urls": list(decision.failover_urls),
+        "sha256": decision.digest,
+        "flags": [flag.value for flag in decision.flags],
+        "reasons": list(decision.reasons),
+        "rollback": None if decision.rollback is None else {
+            "snapshot_path": decision.rollback.snapshot_path,
+            "restore_path": decision.rollback.restore_path,
+            "reason": decision.rollback.reason,
+            "required": decision.rollback.required,
+        },
+    }

--- a/rafaelia/tests/test_download_strategy.py
+++ b/rafaelia/tests/test_download_strategy.py
@@ -1,0 +1,189 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from governance.download_strategy import (
+    ContentKind,
+    DownloadCandidate,
+    DownloadState,
+    RollbackPlan,
+    SafetyFlag,
+    WatchdogPolicy,
+    build_download_strategy,
+    decision_manifest,
+    recognize_content,
+    sha256_bytes,
+)
+
+
+class TestDownloadStrategy(unittest.TestCase):
+    def test_recognizes_apk_by_extension(self):
+        self.assertEqual(recognize_content("release.apk", b"PK\x03\x04"), ContentKind.APK)
+
+    def test_ready_decision_with_failover_mirror(self):
+        payload = b'{"ok": true}'
+        digest = sha256_bytes([payload])
+        decision = build_download_strategy(
+            "manifest.json",
+            payload[:8],
+            [payload],
+            [
+                DownloadCandidate("https://b.example/manifest.json", digest, len(payload), priority=20),
+                DownloadCandidate("https://a.example/manifest.json", digest, len(payload), priority=10),
+            ],
+            WatchdogPolicy(max_retries=1),
+            now=0.0,
+        )
+
+        self.assertEqual(decision.state, DownloadState.READY)
+        self.assertEqual(decision.selected_url, "https://a.example/manifest.json")
+        self.assertEqual(decision.failover_urls, ("https://b.example/manifest.json",))
+        self.assertEqual(decision.flags, ())
+        self.assertEqual(decision_manifest(decision)["sha256"], digest)
+
+    def test_failover_when_primary_hash_mismatches(self):
+        payload = b"safe text"
+        digest = sha256_bytes([payload])
+        decision = build_download_strategy(
+            "notes.txt",
+            payload,
+            [payload],
+            [
+                DownloadCandidate("https://bad.example/notes.txt", "0" * 64, len(payload), priority=1),
+                DownloadCandidate("https://good.example/notes.txt", digest, len(payload), priority=2),
+            ],
+            WatchdogPolicy(),
+            now=0.0,
+        )
+
+        self.assertEqual(decision.state, DownloadState.FAILOVER)
+        self.assertEqual(decision.selected_url, "https://good.example/notes.txt")
+        self.assertIn(SafetyFlag.DIGEST_MISMATCH, decision.flags)
+        self.assertTrue(any("sha256 mismatch" in reason for reason in decision.reasons))
+
+    def test_rollback_when_no_safe_route_remains(self):
+        rollback = RollbackPlan("/snap/last", "/opt/app", "integrity failure", True)
+        decision = build_download_strategy(
+            "payload.bin",
+            b"\x00\x01",
+            [b"\x00\x01"],
+            [DownloadCandidate("https://bad.example/payload.bin", "f" * 64, 2)],
+            WatchdogPolicy(allowed_kinds=(ContentKind.TEXT,)),
+            rollback=rollback,
+            now=0.0,
+        )
+
+        self.assertEqual(decision.state, DownloadState.ROLLBACK)
+        self.assertEqual(decision.rollback, rollback)
+        self.assertIn(SafetyFlag.CONTENT_BLOCKED, decision.flags)
+        self.assertIn(SafetyFlag.DIGEST_MISMATCH, decision.flags)
+        self.assertIsNone(decision.selected_url)
+
+    def test_rejects_insecure_scheme_even_with_valid_digest(self):
+        payload = b"safe text"
+        digest = sha256_bytes([payload])
+        decision = build_download_strategy(
+            "notes.txt",
+            payload,
+            [payload],
+            [DownloadCandidate("http://bad.example/notes.txt", digest, len(payload))],
+            WatchdogPolicy(allowed_schemes=("https",)),
+            now=0.0,
+        )
+
+        self.assertEqual(decision.state, DownloadState.REJECTED)
+        self.assertIn(SafetyFlag.URL_SCHEME_BLOCKED, decision.flags)
+        self.assertIsNone(decision.selected_url)
+
+    def test_requires_compatible_mirror_count_for_enterprise_rollout(self):
+        payload = b'{"ok": true}'
+        digest = sha256_bytes([payload])
+        rollback = RollbackPlan("/snap/stable", "/srv/app", "mirror quorum failure", True)
+        decision = build_download_strategy(
+            "manifest.json",
+            payload,
+            [payload],
+            [
+                DownloadCandidate(
+                    "https://arm.example/manifest.json",
+                    digest,
+                    len(payload),
+                    compatibility=("arm32", "neon"),
+                ),
+                DownloadCandidate(
+                    "https://generic.example/manifest.json",
+                    digest,
+                    len(payload),
+                    priority=2,
+                    compatibility=("generic",),
+                ),
+            ],
+            WatchdogPolicy(
+                min_viable_mirrors=2,
+                required_compatibility=("arm32", "neon"),
+            ),
+            rollback=rollback,
+            now=0.0,
+        )
+
+        self.assertEqual(decision.state, DownloadState.ROLLBACK)
+        self.assertIn(SafetyFlag.MIN_MIRRORS_UNMET, decision.flags)
+        self.assertIsNone(decision.selected_url)
+        self.assertEqual(decision.rollback, rollback)
+
+    def test_manifest_exports_stable_flags_for_audit(self):
+        payload = b"safe text"
+        digest = sha256_bytes([payload])
+        decision = build_download_strategy(
+            "notes.txt",
+            payload,
+            [payload],
+            [DownloadCandidate("http://bad.example/notes.txt", digest, len(payload))],
+            WatchdogPolicy(allowed_schemes=("https",)),
+            now=0.0,
+        )
+        manifest = decision_manifest(decision)
+
+        self.assertEqual(manifest["flags"], [SafetyFlag.URL_SCHEME_BLOCKED.value, SafetyFlag.MIN_MIRRORS_UNMET.value])
+        self.assertEqual(manifest["state"], DownloadState.REJECTED.value)
+
+    def test_watchdog_timeout_for_prior_pipeline_phase_rolls_back(self):
+        payload = b"safe text"
+        digest = sha256_bytes([payload])
+        rollback = RollbackPlan("/snap/stable", "/srv/app", "watchdog timeout", True)
+        decision = build_download_strategy(
+            "notes.txt",
+            payload,
+            [payload],
+            [DownloadCandidate("https://good.example/notes.txt", digest, len(payload))],
+            WatchdogPolicy(timeout_seconds=1.0),
+            rollback=rollback,
+            now=10.0,
+            started_at=8.5,
+        )
+
+        self.assertEqual(decision.state, DownloadState.ROLLBACK)
+        self.assertIn(SafetyFlag.WATCHDOG_TIMEOUT, decision.flags)
+        self.assertEqual(decision.rollback, rollback)
+
+    def test_invalid_policy_rejects_without_selecting_candidate(self):
+        payload = b"safe text"
+        digest = sha256_bytes([payload])
+        decision = build_download_strategy(
+            "notes.txt",
+            payload,
+            [payload],
+            [DownloadCandidate("https://good.example/notes.txt", digest, len(payload))],
+            WatchdogPolicy(min_viable_mirrors=0),
+            now=0.0,
+        )
+
+        self.assertEqual(decision.state, DownloadState.REJECTED)
+        self.assertIn(SafetyFlag.POLICY_INVALID, decision.flags)
+        self.assertIsNone(decision.selected_url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Reduce import overhead and avoid hard failures when optional heavy submodules are unavailable by lazy-loading top-level exports. 
- Provide an enterprise-safe, deterministic decision layer for governance to validate download artifacts and select mirrors without performing network I/O or mutating system state. 
- Surface a stable `__governance_available__` flag to let consumers adapt behavior when governance support is absent. 

### Description

- Implement lazy exports in `rafaelia/__init__.py` via `_LAZY_EXPORTS`, `__getattr__`, optional dependency hints, and a computed `__governance_available__` flag so heavy modules are imported on demand. 
- Add `rafaelia/governance/download_strategy.py` with dataclasses (`DownloadCandidate`, `WatchdogPolicy`, `RollbackPlan`, `StrategyDecision`), enums (`DownloadState`, `ContentKind`, `SafetyFlag`), and functions for content recognition (`recognize_content`), incremental SHA-256 (`sha256_bytes`), deterministic strategy computation (`build_download_strategy`), and manifest serialization (`decision_manifest`). 
- Include robust validation rules (allowed kinds/schemes, size/time bounds, digest and compatibility checks), deterministic candidate ordering, failover selection, and stable audit flags and rollback semantics. 
- Add unit tests in `rafaelia/tests/test_download_strategy.py` covering content recognition, ready/failover/rollback/reject transitions, manifest output, watchdog timeout, and policy validation. 

### Testing

- Ran the new test module with `python -m pytest rafaelia/tests/test_download_strategy.py -q` and all tests succeeded. (9 passed) 
- The tests exercise `build_download_strategy` decision paths including READY, FAILOVER, REJECTED, and ROLLBACK outcomes and the `decision_manifest` serializer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fbaf58c30832d8887da1ad9ca420a)