### PR TITLE
docs(readme): custódia longitudinal V2 e gate 8→1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,78 @@
 # PCR RAFAELIA Code Seed
 
-Entrada canônica de `rafaelmeloreisnovo/PCR_Rafaelia_Code_seed`.
+Entrada canônica e contrato de reconstrução do repositório `rafaelmeloreisnovo/PCR_Rafaelia_Code_seed`.
 
 ```text
-scope             = README_ONLY
-source_branch     = master
-source_head       = a9cc6cf5a36327e7ba3e6fa814552871aea68119
-custody_branch    = docs/readme-custody-8cycle-20260728
-claim_allowed     = false
-certification     = NOT_CLAIMED
-runtime_executed  = false
+repository             = rafaelmeloreisnovo/PCR_Rafaelia_Code_seed
+source_branch          = master
+source_readme_blob     = 294cf3ae86d085fba404f4e3fa5ab45040826344
+custody_branch         = docs/readme-custody-8cycle-v2-20260729
+scope                  = README_ONLY
+claim_allowed          = false
+runtime_executed       = false
+certification          = NOT_CLAIMED
+batch_id               = README-CUSTODY-V2-20260729T223535-0300
+drive_revision_anchor  = 81
+previous_drive_revision= 79
 ```
 
 ## Índice
 
-1. [Origem](#origem)
-2. [Oito ciclos](#oito-ciclos)
-3. [Federação](#federação)
-4. [Retorno 8 → 1](#retorno-8--1)
-5. [Governança](#governança)
-6. [Limites](#limites)
+1. [Origem e linhagem](#origem-e-linhagem)
+2. [Segundo lote de oito ciclos](#segundo-lote-de-oito-ciclos)
+3. [Contrato de reconstrução](#contrato-de-reconstrução)
+4. [Gate 8 → 1](#gate-8--1)
+5. [Governança e limites](#governança-e-limites)
+6. [Retroalimentação](#retroalimentação)
 
-## Origem
+## Origem e linhagem
 
-O README não existia em `master`; esse estado foi preservado como `TOKEN_VAZIO_README_PATH`. O head observado registrava a mensagem:
+O README original não existia antes do primeiro lote; a ausência foi preservada como `TOKEN_VAZIO_README_PATH`. Depois, o V1 foi integrado administrativamente:
+
+| Objeto | Estado observado |
+|---|---|
+| V1 do corpus | PR `#27` mesclado em `66ea7f4927e4b594d6b32eb269ab6346b7871242` |
+| V1 do PCR | PR `#109` mesclado em `8b3bb1f6f406d1419e7f571818e02fdd6adfcc9a` |
+| Raiz final V1 | `8c87638c7e0bb248d19059d8edbb5ec592edd965040032d06e645a2515fcbe87` |
+| Memória longitudinal | Drive revisão `81`, anterior `79` |
+| Persistência | `APPENDING_BEYOND_ONLY` |
+
+Mensagem de commit e merge são metadados de proveniência. Não provam execução Q16, TBB, AVX-512, Maple ou freestanding.
+
+## Segundo lote de oito ciclos
+
+| Ciclo | Função | Estado/commit |
+|---:|---|---|
+| C01 | reancorar corpus após merges V1 | `e4701e93297b0b2c531d3a70ac9051b6c26871e7` |
+| C02 | reancorar PCR após merges V1 | `THIS_DELTA` |
+| C03 | concatenar índice corpus → PCR → Drive | `PENDING` |
+| C04 | concatenar índice PCR → corpus → Drive | `PENDING` |
+| C05 | fixar quatro superfícies e quatro controles | `PENDING` |
+| C06 | fixar gate de retorno 8 → 1 | `PENDING` |
+| C07 | pré-selar receipts e resíduos | `PENDING` |
+| C08 | selar e conferir lote federado | `PENDING` |
+
+### Receipts V2
+
+| Ciclo | SHA3-256 do receipt |
+|---:|---|
+| C01 | `147e6d36eb60e525549d25efb6252112eb3e06cbf09cbe3bfaee9360aed690b4` |
+| C02 | `b0de85f3591aff2990da2f03ba3bc6a24f19be30907bc52e41a74274c8ab913e` |
+
+## Contrato de reconstrução
 
 ```text
-chore(seed): preserve Q16 original and stripped artifact contract
+fonte congelada
+→ índice
+→ relação tipada
+→ transformação em branch
+→ commit
+→ receipt
+→ revisão Drive
+→ checkpoint humano
 ```
 
-Mensagem de commit é metadado de proveniência; não prova execução do contrato Q16.
-
-## Oito ciclos
-
-| Porta | Função | Estado documental |
-|---:|---|---|
-| C01 | canonizar o corpus | confirmado no PR corpus #27 |
-| C02 | criar entrada do PCR | commit `a783878ab80d4dcc2af35cf44e41614d244ab360` |
-| C03 | índice corpus → PCR | commit `8897cda18f3af297b28420bdb2f3dd6a55248fed` |
-| C04 | índice PCR → corpus | commit `0c6b69a70ffa18b415954c170e30b5f659613d2c` |
-| C05 | quatro superfícies + quatro controles | commit `63e2293584678ccef7d99d40de6128dce20d8e3a` |
-| C06 | gate de retorno | commit `e80232fee38fbe62a81a609cadc62c9d9da997d6` |
-| C07 | pré-selagem | `THIS_DELTA` |
-| C08 | selagem e resíduos | `PENDING` |
-
-## Federação
+A relação federada é documental:
 
 ```text
 CONVERSATIONS_CHUNKS_PRIVATE
@@ -56,12 +84,12 @@ PCR_Rafaelia_Code_seed
 CONVERSATIONS_CHUNKS_PRIVATE
 ```
 
-Arestas documentais não implicam equivalência binária, causalidade ou execução compartilhada.
+Aresta documental não demonstra equivalência binária, causalidade, identidade de autoria ou runtime compartilhado.
 
-## Retorno 8 → 1
+## Gate 8 → 1
 
 ```text
-C8 --VERIFY(V)--> C1(next)
+C08 --VERIFY(V)--> C01(next)
 
 V = integrity
   × provenance
@@ -73,102 +101,39 @@ V = integrity
   × unresolved_gap_register
 ```
 
-Se um gate obrigatório estiver ausente:
+Se qualquer gate obrigatório faltar:
 
 ```text
 RETURN_TO_C01 = BLOCKED
 STATE         = TOKEN_VAZIO_RETURN_GATE
 ```
 
-### Custódia dos eventos
-
-#### C02
-
-```text
-SHA3-256  208e4795b2f124ac016d9262c68c95f6bfed2ef675373f0e8088eed452b3fb7c
-BLAKE3    0ec058ebe541c233774812591ad798c35bfeb098e692d4cb87feea8c01d3615f
-SHA-256   148d99ffc5875f1c427b0c40bdca17b1d8b2f40f4e17b066d46080c85c2695d5
-MD5       968ca0f6817058b8bc50ae608f35083a  LEGACY_COMPATIBILITY_ONLY
-```
-
-#### C04
-
-```text
-SHA3-256  58529f92382eb5e1c7c40fd358a95cfe97a43c697e0ac0d933333b67cb417143
-BLAKE3    d3b7d347cd6f6bf6ddd6794cdc98117974ace86422d3dec9cd4427c7c1892afb
-SHA-256   4eefdbbe6b9d1e762150936fed28aea328ac82c7d1715f3754bdfcd377d6f614
-MD5       1b1d131c2601d431791d33df877c21e8  LEGACY_COMPATIBILITY_ONLY
-```
-
-#### C06
-
-```text
-SHA3-256  73dff903204d7a28ec2e72339826ff40a28a94fe03169dd77a7822573202c1bd
-BLAKE3    a7885bb28fdbbb5f81025f93502bb7a97b7dba8719fdff032718e0666ec66158
-SHA-256   259797d0b4474111ab734f7d5493a2c54697613fe2bfa6a64aface5e0e70a3f6
-MD5       c828a35bbce731beb800574f9cfb6e14  LEGACY_COMPATIBILITY_ONLY
-```
-
-O primeiro envio de C06 foi bloqueado pelo filtro do conector antes de qualquer escrita. A repetição usou o mesmo escopo benigno, conteúdo reduzido e `retry=1`.
-
-## Governança
+## Governança e limites
 
 - menor privilégio e separação de funções;
-- proveniência, integridade e rastreabilidade;
-- consistência, completude declarada e qualidade de dados;
+- origem, transformação e prova separadas;
+- revisão Drive distinta de hash criptográfico;
 - falha e contradição preservadas;
-- reversibilidade e melhoria contínua;
-- Drive revision ID separado de hash criptográfico.
-
-Controles alinhados a boas práticas de segurança da informação e qualidade de dados, sem reivindicar certificação.
-
-## Limites
+- nenhuma certificação reivindicada.
 
 ```text
-TBB_RUNTIME        = TOKEN_VAZIO_NOT_EXECUTED
-AVX512_RUNTIME     = TOKEN_VAZIO_NOT_EXECUTED
-MAPLE_TREE_RUNTIME = TOKEN_VAZIO_NOT_EXECUTED
-FREESTANDING_BUILD = TOKEN_VAZIO_NOT_EXECUTED
-MERGE              = false
+TBB_RUNTIME            = TOKEN_VAZIO_NOT_EXECUTED
+AVX512_RUNTIME         = TOKEN_VAZIO_NOT_EXECUTED
+MAPLE_TREE_RUNTIME     = TOKEN_VAZIO_NOT_EXECUTED
+FREESTANDING_BUILD     = TOKEN_VAZIO_NOT_EXECUTED
+ADVANCED_STATISTICS    = TOKEN_VAZIO_FORMAL_PUBLICATION
+EXTERNAL_REVIEW        = TOKEN_VAZIO
+AUTO_MERGE             = false
+REBASE                 = false
+FORCE_PUSH             = false
 ```
 
-## Pré-selagem C07
+## Retroalimentação
 
-### Conferência parcial
+- **F_ok:** PCR reancorado no estado pós-merge.
+- **F_gap:** C03–C08.
+- **F_next:** C03 no corpus.
 
-| Ciclo | Commit | Receipt SHA3-256 |
-|---:|---|---|
-| C01 | `fab7bb9e3ef9413e760a13b1af6e8a0103bed3b8` | `2c550e58a70f4681e18d529bee7ae190524ac1b6cbd6f4203486b196f6a524da` |
-| C02 | `a783878ab80d4dcc2af35cf44e41614d244ab360` | `2e1bbfc3b9e8a41f48b2c6d9bdbee37e03f69547314e9cf699369aee54c2fb7c` |
-| C03 | `8897cda18f3af297b28420bdb2f3dd6a55248fed` | `8be1751ec2003041e485e3978299161dfdab9ab4abcf89c14bc48b10c8f0d6be` |
-| C04 | `0c6b69a70ffa18b415954c170e30b5f659613d2c` | `c464f9e0475919ac8ff053ef493e5dc6668038f7746a3fe74d0943ff7c106919` |
-| C05 | `63e2293584678ccef7d99d40de6128dce20d8e3a` | `8fd2bf030ab577a5db2e382dd6f43d6bb8b9b1c0be3721dda4492fdfdb6b5adf` |
-| C06 | `e80232fee38fbe62a81a609cadc62c9d9da997d6` | `b20898d95437b2097e43bfaa118800390b2885360a776613134d63d8e8aaa229` |
+---
 
-### Resíduos preservados
-
-```text
-PR_MERGEABILITY_RECHECK = PENDING_C08
-TBB_RUNTIME             = TOKEN_VAZIO_NOT_EXECUTED
-AVX512_RUNTIME          = TOKEN_VAZIO_NOT_EXECUTED
-FREESTANDING_BUILD      = TOKEN_VAZIO_NOT_EXECUTED
-EXTERNAL_REVIEW         = TOKEN_VAZIO
-CERTIFICATION           = NOT_CLAIMED
-MERGE                   = false
-```
-
-### Evento C07
-
-```text
-local       2026-07-28T22:54:01-03:00
-utc         2026-07-29T01:54:01Z
-predecessor b20898d95437b2097e43bfaa118800390b2885360a776613134d63d8e8aaa229
-SHA3-256    c522a5aa3273cd8750ad512ada67c2775128aa39cfac7a8063500da95efd4057
-BLAKE3      5019996c573232468a24cc9471c51a43821b17965ba8262d76cafb25bc27ec8f
-SHA-256     708c721ed206010908af62e8f7178e9d268ec24a4d431f88b29262f4837be060
-MD5         33ff91a131e4a405e81f4159b760a3d5  LEGACY_COMPATIBILITY_ONLY
-```
-
-- **F_ok:** seis receipts anteriores reconciliados.
-- **F_gap:** C08 e rechecagem dos PRs.
-- **F_next:** selagem federada C08 no corpus.
+`APPENDING_BEYOND_ONLY · README-CUSTODY-8CYCLE-V2`

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Mensagem de commit e merge são metadados de proveniência. Não provam execuç�
 | C03 | concatenar índice corpus → PCR → Drive | `c39cd47b6ba2d4025d327ce91593cc324504ee68` |
 | C04 | concatenar índice PCR → corpus → Drive | `2f051511eb7d56bbd6afbef664312985a208c123` |
 | C05 | fixar quatro superfícies e quatro controles | `4e5631f20e3fbc17003f3e85ea6c7691e1bf930e` |
-| C06 | fixar gate de retorno 8 → 1 | `THIS_DELTA` |
-| C07 | pré-selar receipts e resíduos | `PENDING` |
+| C06 | fixar gate de retorno 8 → 1 | `a179f8a45e28706e9f8687631aeeb27b006c7a91` |
+| C07 | pré-selar receipts e resíduos | `THIS_DELTA` |
 | C08 | selar e conferir lote federado | `PENDING` |
 
 ### Receipts V2
@@ -61,7 +61,8 @@ Mensagem de commit e merge são metadados de proveniência. Não provam execuç�
 | C03 | `fb58d91f006651baae02a45dffe1fe51acc410fe0ba3b951cf1eb75cd99e45fa` |
 | C04 | `c4ea62bd481c598f7137d492b85eea36c13b8ec3632fd49c424d42ec2ddaf671` |
 | C05 | `b92b5dcd108dd579493e435956d61422f121bbe009505143dc13f96470fb4bc7` |
-| C06 | `810f099203581912bb588201ff4c6e5ddbc69f85b70fde5910ea1af6a8d078a4` |
+| C06 | `8310a9d675385dc0ac3febd27e6dba2763f60b93eb954a27ef980aa0ec2ad5ad` |
+| C07 | `e8ea67f202abb594d30f177ba9cee9b97c631f212d78b482ca3ac299c12ad3bf` |
 
 ## Contrato de reconstrução
 
@@ -134,9 +135,9 @@ FORCE_PUSH             = false
 
 ## Retroalimentação
 
-- **F_ok:** gate 8 → 1 e bloqueios de runtime fixados.
-- **F_gap:** C07–C08.
-- **F_next:** C07 no PCR.
+- **F_ok:** seis receipts reconciliados; `PRESEAL_MERKLE_ROOT_SHA3_256=b0221ff08693efa705929716c2e657b96797241eefd4ac5ef09569b7671c586d`.
+- **F_gap:** C08 e conferência final dos PRs/Drive.
+- **F_next:** C08 no corpus.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Mensagem de commit e merge são metadados de proveniência. Não provam execuç�
 | Ciclo | Função | Estado/commit |
 |---:|---|---|
 | C01 | reancorar corpus após merges V1 | `e4701e93297b0b2c531d3a70ac9051b6c26871e7` |
-| C02 | reancorar PCR após merges V1 | `THIS_DELTA` |
-| C03 | concatenar índice corpus → PCR → Drive | `PENDING` |
-| C04 | concatenar índice PCR → corpus → Drive | `PENDING` |
+| C02 | reancorar PCR após merges V1 | `8d5b7163f26ddee84dbcb493362e47c22b276508` |
+| C03 | concatenar índice corpus → PCR → Drive | `c39cd47b6ba2d4025d327ce91593cc324504ee68` |
+| C04 | concatenar índice PCR → corpus → Drive | `THIS_DELTA` |
 | C05 | fixar quatro superfícies e quatro controles | `PENDING` |
 | C06 | fixar gate de retorno 8 → 1 | `PENDING` |
 | C07 | pré-selar receipts e resíduos | `PENDING` |
@@ -57,7 +57,9 @@ Mensagem de commit e merge são metadados de proveniência. Não provam execuç�
 | Ciclo | SHA3-256 do receipt |
 |---:|---|
 | C01 | `147e6d36eb60e525549d25efb6252112eb3e06cbf09cbe3bfaee9360aed690b4` |
-| C02 | `b0de85f3591aff2990da2f03ba3bc6a24f19be30907bc52e41a74274c8ab913e` |
+| C02 | `46fbd2e2766b29713dbc4f1daa5615fa1781111803a042d0cdc72309089844bc` |
+| C03 | `fb58d91f006651baae02a45dffe1fe51acc410fe0ba3b951cf1eb75cd99e45fa` |
+| C04 | `a64a7abed92a2c3d8df8f163e843d979e5a9a3506b93db63a00450916954f415` |
 
 ## Contrato de reconstrução
 
@@ -130,9 +132,9 @@ FORCE_PUSH             = false
 
 ## Retroalimentação
 
-- **F_ok:** PCR reancorado no estado pós-merge.
-- **F_gap:** C03–C08.
-- **F_next:** C03 no corpus.
+- **F_ok:** índice recíproco PCR → corpus → Drive fixado.
+- **F_gap:** C05–C08.
+- **F_next:** C05 no corpus.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Mensagem de commit e merge são metadados de proveniência. Não provam execuç�
 | C01 | reancorar corpus após merges V1 | `e4701e93297b0b2c531d3a70ac9051b6c26871e7` |
 | C02 | reancorar PCR após merges V1 | `8d5b7163f26ddee84dbcb493362e47c22b276508` |
 | C03 | concatenar índice corpus → PCR → Drive | `c39cd47b6ba2d4025d327ce91593cc324504ee68` |
-| C04 | concatenar índice PCR → corpus → Drive | `THIS_DELTA` |
-| C05 | fixar quatro superfícies e quatro controles | `PENDING` |
-| C06 | fixar gate de retorno 8 → 1 | `PENDING` |
+| C04 | concatenar índice PCR → corpus → Drive | `2f051511eb7d56bbd6afbef664312985a208c123` |
+| C05 | fixar quatro superfícies e quatro controles | `4e5631f20e3fbc17003f3e85ea6c7691e1bf930e` |
+| C06 | fixar gate de retorno 8 → 1 | `THIS_DELTA` |
 | C07 | pré-selar receipts e resíduos | `PENDING` |
 | C08 | selar e conferir lote federado | `PENDING` |
 
@@ -59,7 +59,9 @@ Mensagem de commit e merge são metadados de proveniência. Não provam execuç�
 | C01 | `147e6d36eb60e525549d25efb6252112eb3e06cbf09cbe3bfaee9360aed690b4` |
 | C02 | `46fbd2e2766b29713dbc4f1daa5615fa1781111803a042d0cdc72309089844bc` |
 | C03 | `fb58d91f006651baae02a45dffe1fe51acc410fe0ba3b951cf1eb75cd99e45fa` |
-| C04 | `a64a7abed92a2c3d8df8f163e843d979e5a9a3506b93db63a00450916954f415` |
+| C04 | `c4ea62bd481c598f7137d492b85eea36c13b8ec3632fd49c424d42ec2ddaf671` |
+| C05 | `b92b5dcd108dd579493e435956d61422f121bbe009505143dc13f96470fb4bc7` |
+| C06 | `810f099203581912bb588201ff4c6e5ddbc69f85b70fde5910ea1af6a8d078a4` |
 
 ## Contrato de reconstrução
 
@@ -132,9 +134,9 @@ FORCE_PUSH             = false
 
 ## Retroalimentação
 
-- **F_ok:** índice recíproco PCR → corpus → Drive fixado.
-- **F_gap:** C05–C08.
-- **F_next:** C05 no corpus.
+- **F_ok:** gate 8 → 1 e bloqueios de runtime fixados.
+- **F_gap:** C07–C08.
+- **F_next:** C07 no PCR.
 
 ---
 


### PR DESCRIPTION
## Escopo

Segundo lote README-only, reancorado nos merges V1 e na revisão 81 da memória longitudinal.

## Invariantes

- somente `README.md`;
- `claim_allowed=false`;
- sem código, workflow/YML ou runtime;
- sem rebase, force-push, exclusão ou merge automático;
- TBB, AVX-512, Maple, freestanding e estatística avançada não são promovidos sem receipt.

## Retorno

O gate `C08 → C01(next)` depende da conferência federada completa.